### PR TITLE
RPC exception for custom message and code is added

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Installation
 
 ::
 
-    pip install rpc4django[reST]
+    pip install git+git://github.com/MasoudMax/rpc4django.git
 
 
 Configuration

--- a/rpc4django/jsonrpcdispatcher.py
+++ b/rpc4django/jsonrpcdispatcher.py
@@ -29,6 +29,12 @@ except NameError:
     basestring = str
 
 
+class RPCException(Exception):
+	def __init__(self, message, code):
+		self.message = message
+		self.code = code
+
+
 class JSONRPCDispatcher(object):
     '''
     This class can be used encode and decode jsonrpc messages, dispatch
@@ -123,6 +129,11 @@ class JSONRPCDispatcher(object):
                 except TypeError:
                     # Catch unexpected keyword argument error
                     result = self.methods[jsondict.get('method')](*jsondict.get('params', []))
+            except RPCException as e:
+                # Custom message and code
+                return self._encode_result(jsondict.get('id', ''), None, {
+                    'message': e.message,
+                    'code': e.code})
             except Exception as e:
                 # this catches any error from the called method raising
                 # an exception to the wrong number of params being sent


### PR DESCRIPTION
Sometimes, it's important to have the ability to change error-code, then handling all error-codes in the caller side uniformly in one place.

So, putting a custom exception (e.g. RPCException) with custom message and code, and then catching it in the dispatcher (jsonrpcdispatcher) could solve the issue.

After that, for example, the rpc decorated method can raise `RPCException('My message', 799)`.