### PR TITLE
RPC exception for custom message and code is added

### DIFF
--- a/rpc4django/jsonrpcdispatcher.py
+++ b/rpc4django/jsonrpcdispatcher.py
@@ -6,7 +6,6 @@ see http://json-rpc.org/wiki/specification
 
 import json
 
-
 # indent the json output by this many characters
 # 0 does newlines only and None does most compact
 # This is consistent with SimpleXMLRPCServer output
@@ -28,6 +27,11 @@ except NameError:
     # Python3
     basestring = str
 
+
+class JSONRPCException(Exception):
+    def __init__(self, message, code):
+        self.message = message
+        self.code = code
 
 class JSONRPCDispatcher(object):
     '''
@@ -123,6 +127,10 @@ class JSONRPCDispatcher(object):
                 except TypeError:
                     # Catch unexpected keyword argument error
                     result = self.methods[jsondict.get('method')](*jsondict.get('params', []))
+            except JSONRPCException as e:
+                # Custom message and code
+                return self._encode_result(jsondict.get('id', ''), None, {
+                    'message': e.message, 'code': e.code})
             except Exception as e:
                 # this catches any error from the called method raising
                 # an exception to the wrong number of params being sent


### PR DESCRIPTION
JSONRPCException is added for the ability of creating custom errors (user defined message and code).

However, it's even better to have an ability to modify custom errors in request/response level. But, above suggestion is good too.

(I don't know why it failed in "The Travis CI build".)